### PR TITLE
[NZCSA-093] Disable menu expansion in mobile view

### DIFF
--- a/src/pages/Dashboard/Dashboard.js
+++ b/src/pages/Dashboard/Dashboard.js
@@ -94,6 +94,10 @@ const useStyles = makeStyles((theme) => ({
     backdropFilter: "blur(6px)",
   },
   menuButton: {
+    display: "none",
+    [theme.breakpoints.up("md")]: {
+      display: "block",
+    },
     marginRight: 36,
   },
   menuButtonHidden: {
@@ -284,10 +288,13 @@ export default function Dashboard(props) {
         });
     };
     fetchData();
+  }, [setCurrentUser]);
+  
+  useEffect(() => {
     if (isMobile) {
       setOpen(!open);
     }
-  }, [anchorEl, setCurrentUser]);
+  }, [])
 
   useEffect(() => {
     const fetchData = async () => {


### PR DESCRIPTION
The menu expansion button is disabled for mobile and tablet views. However is still visible for laptop and pc