### PR TITLE
Lunar calendar

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "react-scripts": "4.0.3",
     "react-spinners": "^0.11.0",
     "short-hash": "^1.0.0",
+    "solarlunar": "^2.0.7",
     "swiper": "^6.8.4",
     "uuid": "^8.3.2",
     "web-vitals": "^1.1.1",

--- a/src/App.js
+++ b/src/App.js
@@ -17,6 +17,7 @@ import { AuthProvider } from "./context/auth.context";
 import { DarkModeContext } from "./context/darkMode";
 
 import PrivateRoute from "./components/routing/PrivateRoute";
+import AdaptiveSearchPanel from "./components/AdaptiveSearchPanel";
 
 function App() {
   const { darkMode } = useContext(DarkModeContext)
@@ -50,6 +51,10 @@ function App() {
           <header className="App-header">
             <Router>
               <Switch>
+                {/* Where HONGCHEN test the function */}
+                <Route path="/test/hongchen-search" exact>
+                  <AdaptiveSearchPanel />
+                </Route>
                 <PrivateRoute exact path="/checkout">
                   <Dashboard checkout={true} />
                 </PrivateRoute>
@@ -83,6 +88,7 @@ function App() {
                 <PrivateRoute path="/:id">
                   <Dashboard />
                 </PrivateRoute>
+
               </Switch>
             </Router>
           </header>

--- a/src/components/AdaptiveSearchPanel.js
+++ b/src/components/AdaptiveSearchPanel.js
@@ -1,0 +1,8 @@
+import { getLunar } from "../utils/LunarCalendar"
+
+export default function (){
+    const test = ()=>{
+        getLunar()
+    }
+    return <div onClick={test}>TEST</div>
+}

--- a/src/utils/LunarCalendar.js
+++ b/src/utils/LunarCalendar.js
@@ -1,0 +1,27 @@
+import solarLunar from 'solarlunar';
+
+export function DayOrToday(date) {
+    if (!date) {
+        var today = new Date()
+        return [today.getFullYear(), today.getMonth() + 1, today.getDate()]
+    } else {
+        return date
+    }
+}
+export function NumberTC(i) {
+    const cnn = ['零', '壹', '贰', '叁', '肆', '伍', '陆', '柒', '捌', '玖']
+    return cnn[parseInt(i)]
+}
+export function getLunar(date) {
+    var day = DayOrToday(date)
+    var dt = solarLunar.solar2lunar(...day)
+    var obj =  {
+        yy: day[0].toString().split('').map(e=>NumberTC(e)).join(""),
+        y: dt.gzYear,
+        m: dt.monthCn,
+        d: dt.dayCn,
+        a: dt.animal
+    }
+    console.log(obj)
+    return obj
+}


### PR DESCRIPTION
## Description
A util class that won't affect overall structure

## Usage

~~~
import {getLunar} from ...
var lunarDate = getLunar() // not param, default to today
// or
var lunarDate = getLunar([2022, 4, 15]) // manually enter date

console.log(lunarDate)

----------------------
{
  a: "虎"
  d: "十五"
  m: "三月"
  y: "壬寅"
  yy: "贰零贰贰"
}
~~~

## How has this been tested?
Test by hand

## Screenshots


## Checklist
*(Leave blank if not applicable)*

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have checked my code and corrected any misspellings
